### PR TITLE
Add co2 checksum verification.

### DIFF
--- a/pmsensor/co2sensor.py
+++ b/pmsensor/co2sensor.py
@@ -48,10 +48,19 @@ def read_mh_z19_with_temperature(serial_device):
             sbuf += ser.read(1)
 
             if len(sbuf) == MHZ19_SIZE:
-                # TODO: check checksum
+                logger.debug("Finished reading data %s", sbuf)
+
+                received_checksum = sbuf[-1]
+                logger.debug("received_checksum: %s", received_checksum)
+                # checksum: (NOT (Byte1+Byte1+Byte2+Byte3+Byte5+Byte6+Byte7)) + 1
+                calculated_checksum = (~sum(bytearray(sbuf[1:8])) & 0xFF) + 1
+                logger.debug("calculated_checksum: %s", calculated_checksum)
+                if sbuf[0] != 0xFF or received_checksum != calculated_checksum:
+                    logger.error('bad checksum for data: %s received: %s calculated: %s',
+                                 sbuf, received_checksum, calculated_checksum)
+                    return None
 
                 res = (sbuf[2]*256 + sbuf[3], sbuf[4] - 40)
-                logger.debug("Finished reading data %s", sbuf)
                 finished = True
 
         else:


### PR DESCRIPTION
A bad checksum should raise an exception but we stay consistent with the rest of the code and return None if the checksum fails.

Note: My just-plugged in MH-Z19B sensor will return, in order:
- A bad checksum
- An incorrect PPM value of 1215, twice
- 410 PPM for approximately one more minute until the device has warmed up.

As this code doesn't know its history it's up to the calling function to keep track and potentially blacklist these values.