### PR TITLE
Added function to disable ABC logic at mhz19

### DIFF
--- a/pmsensor/co2sensor.py
+++ b/pmsensor/co2sensor.py
@@ -10,19 +10,33 @@ import serial
 MHZ19_SIZE = 9
 MZH19_READ = [0xff, 0x01, 0x86, 0x00, 0x00, 0x00, 0x00, 0x00, 0x79]
 MZH19_RESET = [0xff, 0x01, 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78]
+MHZ19_DISABLE_ABC = [0xff, 0x01, 0x79, 0x00, 0x00, 0x00, 0x00, 0x00, 0x86]
+
+def send_data(data, serial_device):
+    """Send data to device"""
+
+    ser = serial.Serial(port=serial_device,
+                        baudrate=9600,
+                        parity=serial.PARITY_NONE,
+                        stopbits=serial.STOPBITS_ONE,
+                        bytesize=serial.EIGHTBITS)
+    ser.write(data)
+
+    return None
+
+def disable_ABC_logic(serial_device):
+    """Disable automatic baseline correction"""
+
+    send_data(MHZ19_DISABLE_ABC, serial_device)
+
+    return None
 
 def reset_mh_z19(serial_device):
     """reset to zero"""    
 
     logger = logging.getLogger(__name__)
 
-    ser = serial.Serial(port=serial_device,
-                        baudrate=9600,
-                        parity=serial.PARITY_NONE,
-                        stopbits=serial.STOPBITS_ONE,
-                        bytesize=serial.EIGHTBITS)    
-
-    ser.write(MZH19_RESET)
+    send_data(MZH19_RESET, serial_device)
 
     return None
 
@@ -41,18 +55,12 @@ def read_mh_z19_with_temperature(serial_device):
 
     logger = logging.getLogger(__name__)
 
-    ser = serial.Serial(port=serial_device,
-                        baudrate=9600,
-                        parity=serial.PARITY_NONE,
-                        stopbits=serial.STOPBITS_ONE,
-                        bytesize=serial.EIGHTBITS)
-
     sbuf = bytearray()
     starttime = time.time()
     finished = False
     timeout = 2
     res = None
-    ser.write(MZH19_READ)
+    send_data(MZH19_READ, serial_device)
     while not finished:
         mytime = time.time()
         if mytime - starttime > timeout:


### PR DESCRIPTION
Automatic baseline correction (ABC) drops 400ppm level to lowest value for
  last 24 hours, that is not good for regular usage.
According to https://www.winsen-sensor.com/d/files/infrared-gas-sensor/mh-z19b-co2-ver1_0.pdf and https://revspace.nl/MHZ19 we may dsable ABC at this device by sending 0x79 command.
So we may let user to decide: use ABC or not.