### PR TITLE
Add support for Nova SDL607 PM meter & bump version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ This library lets you read sensor data from serial-connected particulate matter 
 
 - OneAir A3
 - Nova Fitness SDS021
+- Nova Fitness SDL607
 - Plantower PMS1003
 - Plantower PMS2003
 - Plantower PMS3003

--- a/pmsensor/serial_pm.py
+++ b/pmsensor/serial_pm.py
@@ -38,13 +38,29 @@ ONEAIR_S3 = {
     TIMEOUT: 2
 }
 
-NOVA = {
+NOVA_SDS = {
     "name": "Nova SDS0x1",
     STARTBLOCK: bytes([0xaa, 0xc0]),
     RECORD_LENGTH: 10,
     PM_1_0: None,
     PM_2_5: 2,
     PM_10: 4,
+    BAUD_RATE: 9600,
+    BYTE_ORDER: LSB,
+    MULTIPLIER: 0.1,
+    TIMEOUT: 2
+}
+
+# Data from
+# https://github.com/cezbloch/smog/blob/master/SmogMeters.py
+# PCB internal marking "SDL307"
+NOVA_SDL = {
+    'name': 'Nova SDLx07',
+    STARTBLOCK: bytes([0xaa, 0xa5]),
+    RECORD_LENGTH: 19,
+    PM_1_0: None,
+    PM_2_5: 7,
+    PM_10: 11,
     BAUD_RATE: 9600,
     BYTE_ORDER: LSB,
     MULTIPLIER: 0.1,
@@ -82,8 +98,9 @@ PLANTOWER2 = {
 
 SUPPORTED_SENSORS = {
     "oneair,s3": ONEAIR_S3,
-    "novafitness,sds021": NOVA,
-    "novafitness,sds011": NOVA,
+    "novafitness,sds021": NOVA_SDS,
+    "novafitness,sds011": NOVA_SDS,
+    "novafitness,sdl607": NOVA_SDL,
     "plantower,pms1003": PLANTOWER1,
     "plantower,pms5003": PLANTOWER1,
     "plantower,pms7003": PLANTOWER1,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pmsensor',
-      version='0.3',
+      version='0.5',
       description='Library to read data from environment ensors',
       url='https://github.com/open-homeautomation/pmsensor',
       author='Daniel Matuschek',


### PR DESCRIPTION
Ideally to be merged after [the previous PR](https://github.com/open-homeautomation/pmsensor/pull/13) to respect order of the queue.

---
Also, please tell us whether you have abandoned this project. This project's PyPI is a dependency for a [home assistant core integration](https://www.home-assistant.io/integrations/serial_pm/).